### PR TITLE
rename field_masks -> masks

### DIFF
--- a/src/jungles/bitfields.hpp
+++ b/src/jungles/bitfields.hpp
@@ -112,7 +112,7 @@ class Bitfields {
   }
 
   static inline constexpr auto to_non_shifted_field_masks() noexcept {
-    std::array<UnderlyingType, NumberOfFields> field_masks = {};
+    std::array<UnderlyingType, NumberOfFields> masks = {};
 
     for (unsigned i{0}; i < NumberOfFields; ++i) {
       auto field_size{static_cast<UnderlyingType>(field_sizes[i])};
@@ -122,13 +122,13 @@ class Bitfields {
       // https://stackoverflow.com/questions/10499104/is-shifting-more-than-32-bits-of-a-uint64-t-integer-on-an-x86-machine-undefined#answer-10499371
       auto one{static_cast<UnderlyingType>(1)};
       if (field_size == UnderlyingTypeBitSize) {
-        field_masks[i] = static_cast<UnderlyingType>(~0x0);
+        masks[i] = static_cast<UnderlyingType>(~0x0);
       } else {
-        field_masks[i] = (one << field_size) - 1;
+        masks[i] = (one << field_size) - 1;
       }
     }
 
-    return field_masks;
+    return masks;
   }
 
   static inline constexpr auto to_shifted_field_masks() noexcept {


### PR DESCRIPTION
This resolves warnings about field_masks shadowing a static data member.